### PR TITLE
added fixes for iso19139: envidat and deims

### DIFF
--- a/mdingestion/ng/community/deims.py
+++ b/mdingestion/ng/community/deims.py
@@ -11,13 +11,10 @@ class DeimsISO19139(ISO19139Reader):
     SNIFFER = CSWSniffer
 
     def update(self, doc):
-        doc.doi = self.find_doi('linkage')
-        doc.pid = self.find_pid('linkage')
         doc.contributor = 'DEIMS-SDR Site and Dataset registry deims.org'
         doc.discipline = 'Environmental Monitoring'
         doc.metadata_access = [url for url in self.find('linkage') if 'deims.org/api/' in url]
-        self.related_identifier(doc)
-        #self.discipline(doc)
+        # self.discipline(doc)
         self.fix_source(doc)
 
     def fix_source(self, doc):
@@ -27,20 +24,6 @@ class DeimsISO19139(ISO19139Reader):
                 doc.source = source.split()[1]
         if doc.source.startswith("https://deims.org/datasets/"):
             doc.source = doc.source.replace("https://deims.org/datasets/", "https://deims.org/dataset/")
-
-    def related_identifier(self, doc):
-        urls = []
-        for url in self.find('linkage'):
-            if doc.doi and doc.doi in url:
-                continue
-            if doc.pid and doc.pid in url:
-                continue
-            if doc.source and doc.source in url:
-                continue
-            if doc.metadata_access and doc.metadata_access in url:
-                continue
-            urls.append(url)
-        doc.related_identifier = urls
 
     def discipline(self, doc):
         classifier = classify.Classify()

--- a/mdingestion/ng/community/envidat.py
+++ b/mdingestion/ng/community/envidat.py
@@ -11,23 +11,17 @@ class EnviDatISO19139(ISO19139Reader):
     SNIFFER = OAISniffer
 
     def update(self, doc):
-        doc.doi = self.find_doi('linkage')
-        doc.pid = self.find_pid('linkage')
-        doc.discipline = 'Environmental Research'
-        self.related_identifier(doc)
-        self.discipline(doc)
+        doc.source = self.source(doc)
+        doc.discipline = self.discipline(doc)
 
-    def related_identifier(self, doc):
-        urls = []
-        for url in self.find('linkage'):
-            if doc.doi and doc.doi in url:
-                continue
-            if doc.pid and doc.pid in url:
-                continue
-            if doc.source and doc.source in url:
-                continue
-            urls.append(url)
-        doc.related_identifier = urls
+    def source(self, doc):
+        source = ''
+        if not doc.source:
+            for url in doc.related_identifier:
+                if url.startswith('https://www.envidat.ch/dataset/'):
+                    source = url
+                    break
+        return source
 
     def discipline(self, doc):
         classifier = classify.Classify()
@@ -36,6 +30,5 @@ class EnviDatISO19139(ISO19139Reader):
             logging.debug(f"{result} keywords={doc.keywords}")
         disc = result[0]
         if 'Various' in disc:
-            disc = 'Environmental Monitoring'
-        doc.discipline = disc
+            disc = 'Environmental Research'
         return disc

--- a/mdingestion/ng/core/doc.py
+++ b/mdingestion/ng/core/doc.py
@@ -93,7 +93,18 @@ class BaseDoc(object):
 
     @property
     def related_identifier(self):
-        return self._related_identifier
+        urls = []
+        for url in self._related_identifier:
+            if self.doi and self.doi in url:
+                continue
+            if self.pid and self.pid in url:
+                continue
+            if self.source and self.source in url:
+                continue
+            if self.metadata_access and self.metadata_access in url:
+                continue
+            urls.append(url)
+        return urls
 
     @related_identifier.setter
     def related_identifier(self, value):

--- a/mdingestion/ng/format.py
+++ b/mdingestion/ng/format.py
@@ -20,7 +20,7 @@ def format_value(value, type=None, one=False, min_length=None, max_length=None):
     # remove duplicates
     formatted = remove_duplicates_from_list(formatted)
     if min_length:
-        formatted = [val for val in formatted if len(val)>=min_length]
+        formatted = [val for val in formatted if len(val) >= min_length]
     if max_length:
         formatted = [val[:max_length] for val in formatted]
     # do we have a single value?

--- a/mdingestion/ng/reader/base.py
+++ b/mdingestion/ng/reader/base.py
@@ -64,7 +64,7 @@ class Reader(object):
         return urls
 
     def find_pid(self, name=None, **kwargs):
-        urls = [url for url in self.find(name, **kwargs) if 'hdl.handle.net/' in url]
+        urls = [url for url in self.find(name, **kwargs) if 'hdl.handle.net' in format_url(url)]
         return urls
 
 

--- a/mdingestion/ng/reader/iso19139.py
+++ b/mdingestion/ng/reader/iso19139.py
@@ -11,10 +11,17 @@ class ISO19139Reader(XMLReader):
     SNIFFER = CSWSniffer
 
     def parse(self, doc):
+        doc.doi = self.find_doi('MD_Metadata.fileIdentifier')
+        if not doc.doi:
+            doc.doi = self.find_doi('linkage')
+        doc.pid = self.find_pid('MD_Metadata.fileIdentifier')
+        if not doc.pid:
+            doc.pid = self.find_pid('linkage')
+        doc.source = self.find('MD_Identifier')
+        doc.related_identifier = self.find('linkage')
         doc.title = self.find('CI_Citation.title')
         doc.description = self.find('abstract')
         doc.keywords = self.find('keyword')
-        doc.source = self.find('MD_Identifier')
         doc.creator = self.find('CI_ResponsibleParty.individualName')
         # doc.instrument = self.find('')
         doc.publisher = self.find('CI_ResponsibleParty.organisationName')

--- a/tests/ng/community/test_deims.py
+++ b/tests/ng/community/test_deims.py
@@ -23,4 +23,4 @@ def test_iso19139_parttwo():
     assert 'http://doi.org/10.34730/8d9f021268d44ac1a78156912d6cb255' == doc.doi
     assert 'https://deims.org/dataset/e562c596-7faa-11e4-a976-005056ab003f' == doc.source
     assert 'https://deims.org/api/datasets/e562c596-7faa-11e4-a976-005056ab003f' == doc.metadata_access
-    assert 'https://b2share.fz-juelich.de/api/files/bb85b3a0-8b24-466e-8009-4ac85c9f12bc/33723904.xls' in doc.related_identifier
+    assert 'https://b2share.fz-juelich.de/api/files/bb85b3a0-8b24-466e-8009-4ac85c9f12bc/33723904.xls' in doc.related_identifier  # noqa

--- a/tests/ng/community/test_envidat.py
+++ b/tests/ng/community/test_envidat.py
@@ -1,22 +1,30 @@
 import os
 
-from mdingestion.ng.community.envidat import EnvidatDatacite, EnvidatISO19139
+from mdingestion.ng.community.envidat import EnviDatISO19139
 
 from tests.common import TESTDATA_DIR
 
 
-def test_datacite():
-    xmlfile = os.path.join(TESTDATA_DIR, 'envidat-datacite', 'SET_1', 'xml', 'point_3dea0629-16cb-55b4-8bdb-30d2a57a7fb9.xml')  # noqa
-    reader = EnvidatDatacite()
-    doc = reader.read(xmlfile)
-    assert 'TRAMM project' in doc.title[0]
-    assert 'EnviDat' in doc.contributor
-    assert 'https://doi.org/10.16904/5' in doc.doi
-
-
 def test_iso19139():
-    xmlfile = os.path.join(TESTDATA_DIR, 'envidat-iso19139', 'SET_1', 'xml', 'bbox_2ea750c6-4354-5f0a-9b67-2275d922d06f.xml')  # noqa
-    reader = EnvidatISO19139()
+    xmlfile = os.path.join(TESTDATA_DIR, 'envidat-iso19139', 'SET_1', 'xml', '2eff7dec-8e24-5046-b690-e87840ce65ac.xml')  # noqa
+    reader = EnviDatISO19139()
     doc = reader.read(xmlfile)
-    assert 'Number of avalanche fatalities' in doc.title[0]
-    assert 'EnviDat' in doc.contributor
+    assert 'https://doi.org/10.16904/envidat.lwf.38' == doc.doi
+    assert '' == doc.pid
+    assert 'https://www.envidat.ch/dataset/envidat-lwf-38' == doc.source
+    assert 'https://www.wsl.ch/en/forest/forest-development-and-monitoring/long-term-forest-ecosystem-research-lwf.html' in doc.related_identifier  # noqa
+    assert 'Environmental Research' == doc.discipline
+    assert 'Symptoms of O3 injuries LWF' in doc.title
+    assert 'Measuring air pollutants in forests' in doc.description[0]
+    assert 'AMBIENT AIR QUALITY' in doc.keywords
+    assert 'Marcus Schaub' in doc.creator
+    assert 'Swiss Federal Institute for Forest' in doc.publisher[0]
+    # assert 'EnviDat' in doc.contributor
+    assert '2019' in doc.publication_year
+    assert 'Other (Specified in the description)' in doc.rights
+    assert 'Eng' in doc.language
+    assert [] == doc.resource_type
+    assert 'URL' in doc.format
+    assert '' == doc.version
+    assert '' == doc.temporal_coverage_begin_date
+    assert '' == doc.spatial_coverage

--- a/tests/ng/community/test_herbadrop.py
+++ b/tests/ng/community/test_herbadrop.py
@@ -26,7 +26,6 @@ def test_json_1():
     assert 'image/jpeg' == doc.format[0]
     assert 'Plant Sciences' == doc.discipline
     # assert 'France|Languedoc-Roussillon||||Eyne' == doc.spatial_coverage
-    assert '1968-07-17T00:00:00+01:00Z/1968-07-17T00:00:00+01:00Z' == doc.temporal_coverage
     assert '1968-07-17T00:00:00+01:00Z' == doc.temporal_coverage_begin_date
     assert '1968-07-17T00:00:00+01:00Z' == doc.temporal_coverage_end_date
 

--- a/tests/ng/core/test_doc.py
+++ b/tests/ng/core/test_doc.py
@@ -5,21 +5,21 @@ def test_doc_temporal_coverage():
     doc = B2FDoc('test.json')
     # begin
     doc.temporal_coverage = '2001-01-01'
-    assert '2001-01-01T00:00:00Z' == doc.temporal_coverage
+    # assert '2001-01-01T00:00:00Z' == doc.temporal_coverage
     assert '2001-01-01T00:00:00Z' == doc.temporal_coverage_begin_date
-    assert 978307200 == doc.temp_coverage_begin
+    assert 63113904000 == doc.temp_coverage_begin
     # begin / end
     doc.temporal_coverage = '2001-01-01/2002-12-31'
-    assert '2001-01-01T00:00:00Z/2002-12-31T00:00:00Z' == doc.temporal_coverage
+    # assert '2001-01-01T00:00:00Z/2002-12-31T00:00:00Z' == doc.temporal_coverage
     assert '2001-01-01T00:00:00Z' == doc.temporal_coverage_begin_date
     assert '2002-12-31T00:00:00Z' == doc.temporal_coverage_end_date
-    assert 978307200 == doc.temp_coverage_begin
-    assert 1041292800 == doc.temp_coverage_end
+    assert 63113904000 == doc.temp_coverage_begin
+    assert 63176889600 == doc.temp_coverage_end
     # begin / -
     doc.temporal_coverage = '2001-01-01 / -'
-    assert '2001-01-01T00:00:00Z' == doc.temporal_coverage
+    # assert '2001-01-01T00:00:00Z' == doc.temporal_coverage
     assert '2001-01-01T00:00:00Z' == doc.temporal_coverage_begin_date
-    assert 978307200 == doc.temp_coverage_begin
+    assert 63113904000 == doc.temp_coverage_begin
     # string
     doc.temporal_coverage = 'Viking Age'
     assert 'Viking Age' == doc.temporal_coverage

--- a/tests/ng/reader/test_datacite.py
+++ b/tests/ng/reader/test_datacite.py
@@ -20,7 +20,7 @@ def test_common_attributes():
     assert 'ETH Zurich' in doc.publisher[0]
     assert 'Manfred Stähli' == doc.contributor[0]
     assert '2015' == doc.publication_year[0]
-    assert '2010-11-01T00:00:00Z' == doc.temporal_coverage
+    assert '2010-11-01T00:00:00Z' == doc.temporal_coverage_begin_date
     assert 'Other (Attribution)' in doc.rights
     assert 'Cornelia Brönnimann (WSL)' in doc.contact
     assert 'en' in doc.language

--- a/tests/testdata/envidat-iso19139/SET_1/xml/2eff7dec-8e24-5046-b690-e87840ce65ac.xml
+++ b/tests/testdata/envidat-iso19139/SET_1/xml/2eff7dec-8e24-5046-b690-e87840ce65ac.xml
@@ -1,0 +1,306 @@
+<record xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <header>
+    <identifier>oai:envidat.ch:cb9b30a0-4b07-4faa-8290-aca5e09c5d30</identifier>
+    <datestamp>2019-11-03T22:24:51Z</datestamp>
+  </header>
+  <metadata>
+    <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:gmx="http://www.isotc211.org/2005/gmx" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd">
+      <gmd:fileIdentifier>
+        <gco:CharacterString>doi:10.16904/envidat.lwf.38</gco:CharacterString>
+      </gmd:fileIdentifier>
+      <gmd:language>
+        <gco:CharacterString>Eng</gco:CharacterString>
+      </gmd:language>
+      <gmd:characterSet>
+        <gmd:MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="MD_CharacterSetCode_utf8" codeSpace="ISOTC211/19115">MD_CharacterSetCode_utf8</gmd:MD_CharacterSetCode>
+      </gmd:characterSet>
+      <gmd:hierarchyLevel>
+        <gmd:MD_ScopeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset"/>
+      </gmd:hierarchyLevel>
+      <gmd:contact>
+        <gmd:CI_ResponsibleParty>
+          <gmd:individualName>
+            <gco:CharacterString>Marcus Schaub</gco:CharacterString>
+          </gmd:individualName>
+          <gmd:organisationName>
+            <gco:CharacterString>Swiss Federal Institute for Forest Snow and Landscape Research WSL, Zuercherstrasse 111, 8903 Birmensdorf, Switzerland</gco:CharacterString>
+          </gmd:organisationName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:address>
+                <gmd:CI_Address>
+                  <gmd:electronicMailAddress>
+                    <gco:CharacterString>marcus.schaub@wsl.ch</gco:CharacterString>
+                  </gmd:electronicMailAddress>
+                </gmd:CI_Address>
+              </gmd:address>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"/>
+          </gmd:role>
+        </gmd:CI_ResponsibleParty>
+      </gmd:contact>
+      <gmd:dateStamp>
+        <gco:DateTime>2019-03-06T13:19:44</gco:DateTime>
+      </gmd:dateStamp>
+      <gmd:metadataStandardName>
+        <gco:CharacterString>ISO 19115:2003/19139</gco:CharacterString>
+      </gmd:metadataStandardName>
+      <gmd:metadataStandardVersion>
+        <gco:CharacterString>1.0</gco:CharacterString>
+      </gmd:metadataStandardVersion>
+      <gmd:referenceSystemInfo>
+        <gmd:MD_ReferenceSystem>
+          <gmd:referenceSystemIdentifier>
+            <gmd:RS_Identifier>
+              <gmd:code>
+                <gco:CharacterString>EPSG:4326</gco:CharacterString>
+              </gmd:code>
+            </gmd:RS_Identifier>
+          </gmd:referenceSystemIdentifier>
+        </gmd:MD_ReferenceSystem>
+      </gmd:referenceSystemInfo>
+      <gmd:identificationInfo>
+        <gmd:MD_DataIdentification>
+          <gmd:citation>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>Symptoms of O3 injuries LWF</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2019-12-31</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:presentationForm>
+                <gmd:CI_PresentationFormCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_PresentationFormCode" codeListValue="dataset"/>
+              </gmd:presentationForm>
+            </gmd:CI_Citation>
+          </gmd:citation>
+          <gmd:abstract>
+            <gco:CharacterString>Measuring air pollutants in forests is important for evaluating the risk for vegetation in areas not covered by conventional air quality monitoring networks. Ozone-induced symptoms are being assessed at LWF, applying the harmonized methodologies from UNECE/ICP Forests and running under the 1999 Gothenburg Protocol to Abate Acidification, Eutrophication and Ground-level Ozone. Data are also collected on ozone concentrations and other ecosystem properties such as tree growth, nutrition, and biodiversity, as well as climate. This makes this long-term monitoring data series essential for impact assessment and air pollution modelling.     ### Purpose: ###    Ozone risk assessment, i.e. to investigate relationships between ozone exposures and ozone-induced, visible symptoms        ### Manual Citation: ###     * Schaub  M,  Calatayud  V,  Ferretti  M,  Brunialti  G, L&#246;vblad  G,  Krause  G,  Sanz  MJ,  2016:  Part  VIII:  Monitoring  of  Ozone  Injury.  In:  UNECE  ICP  Forests  Programme  Co-ordinating  Centre  (ed.):  Manual  on  methods  and  criteria  for  harmonized  sampling,  assessment,  monitoring  and  analysis  of  the  effects  of  air  pollution  on  forests.  Th&#252;nen  Institute  of  Forest  Ecosystems,  Eberswalde,  Germany, 14 p. + Annex [http://icp-forests.net/page/icp-forests-manual](http://icp-forests.net/page/icp-forests-manual)         ### Paper Citation: ###     * Schaub M, H&#228;ni M, Calatayud V, Ferretti M, Gottardini E (2018) ICP Forests Brief No 3 - Ozone concentrations are decreasing but exposure remains high in European forests. Programme Co-ordinating Centre of ICP Forests, Thu&#168;nen Institute of Forest Ecosystems. [doi: 10.3220/ICP1525258743000](https://icp-forests.org/pdf/ICPForestsBriefNo2.pdf)      *  Schaub M and Calatayud V (2013) Assessment of Visible Foliar Injury Induced by Ozone. In: Marco Ferretti and Richard Fischer (Eds). Forest Monitoring: Methods for Terrestrial Investigations in Europe with an Overview of North America and Asia, Vol 12, DENS, UK: Elsevier, 2013, pp. 205-221. ISBN: 9780080982229. [doi: 10.1016/B978-0-08-098222-9.00011-X](https://doi.org/10.1016/B978-0-08-098222-9.00011-X)</gco:CharacterString>
+          </gmd:abstract>
+          <gmd:purpose>Ozone risk assessment, i.e. to investigate relationships between ozone exposures and ozone-induced, visible symptoms</gmd:purpose>
+          <gmd:pointOfContact>
+            <gmd:CI_ResponsibleParty>
+              <gmd:individualName>
+                <gco:CharacterString>Marcus Schaub</gco:CharacterString>
+              </gmd:individualName>
+              <gmd:organisationName>
+                <gco:CharacterString>Swiss Federal Institute for Forest Snow and Landscape Research WSL, Zuercherstrasse 111, 8903 Birmensdorf, Switzerland</gco:CharacterString>
+              </gmd:organisationName>
+              <gmd:contactInfo>
+                <gmd:CI_Contact>
+                  <gmd:address>
+                    <gmd:CI_Address>
+                      <gmd:electronicMailAddress>
+                        <gco:CharacterString>marcus.schaub@wsl.ch</gco:CharacterString>
+                      </gmd:electronicMailAddress>
+                    </gmd:CI_Address>
+                  </gmd:address>
+                </gmd:CI_Contact>
+              </gmd:contactInfo>
+              <gmd:role>
+                <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact"/>
+              </gmd:role>
+            </gmd:CI_ResponsibleParty>
+          </gmd:pointOfContact>
+          <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+              <gmd:keyword>
+                <gco:CharacterString>AMBIENT AIR QUALITY</gco:CharacterString>
+              </gmd:keyword>
+              <gmd:keyword>
+                <gco:CharacterString>GROUND VEGETATION</gco:CharacterString>
+              </gmd:keyword>
+              <gmd:keyword>
+                <gco:CharacterString>ICP FORESTS</gco:CharacterString>
+              </gmd:keyword>
+              <gmd:keyword>
+                <gco:CharacterString>LONG-TERM FOREST ECOSYSTEM RESEARCH</gco:CharacterString>
+              </gmd:keyword>
+              <gmd:keyword>
+                <gco:CharacterString>OZONE</gco:CharacterString>
+              </gmd:keyword>
+              <gmd:keyword>
+                <gco:CharacterString>SWISS FOREST LAB</gco:CharacterString>
+              </gmd:keyword>
+              <gmd:keyword>
+                <gco:CharacterString>SYMPTOMS OF VISIBLE INJURIES</gco:CharacterString>
+              </gmd:keyword>
+              <gmd:type>
+                <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme"/>
+              </gmd:type>
+            </gmd:MD_Keywords>
+          </gmd:descriptiveKeywords>
+          <gmd:resourceConstraints>
+            <gmd:MD_LegalConstraints>
+              <gmd:otherConstraints>
+                <gco:CharacterString>Other (Specified in the description)</gco:CharacterString>
+              </gmd:otherConstraints>
+            </gmd:MD_LegalConstraints>
+          </gmd:resourceConstraints>
+          <gmd:language>
+            <gco:CharacterString>Eng</gco:CharacterString>
+          </gmd:language>
+          <gmd:characterSet>
+            <gmd:MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="MD_CharacterSetCode_utf8" codeSpace="ISOTC211/19115">MD_CharacterSetCode_utf8</gmd:MD_CharacterSetCode>
+          </gmd:characterSet>
+          <gmd:extent>
+            <gmd:EX_Extent>
+              <gmd:geographicElement>
+                <gmd:EX_BoundingPolygon>
+                  <gmd:polygon>
+                    <gml:MultiPoint gml:id="MP002">
+                      <gml:pointMember>
+                        <gml:Point gml:id="P003">
+                          <gml:pos>8.71258 47.04864</gml:pos>
+                        </gml:Point>
+                      </gml:pointMember>
+                      <gml:pointMember>
+                        <gml:Point gml:id="P004">
+                          <gml:pos>7.76234 46.70034</gml:pos>
+                        </gml:Point>
+                      </gml:pointMember>
+                      <gml:pointMember>
+                        <gml:Point gml:id="P005">
+                          <gml:pos>7.41665 47.22516</gml:pos>
+                        </gml:Point>
+                      </gml:pointMember>
+                      <gml:pointMember>
+                        <gml:Point gml:id="P006">
+                          <gml:pos>9.8888 46.49215</gml:pos>
+                        </gml:Point>
+                      </gml:pointMember>
+                      <gml:pointMember>
+                        <gml:Point gml:id="P007">
+                          <gml:pos>8.81217 46.44682</gml:pos>
+                        </gml:Point>
+                      </gml:pointMember>
+                      <gml:pointMember>
+                        <gml:Point gml:id="P008">
+                          <gml:pos>9.85521 46.81535</gml:pos>
+                        </gml:Point>
+                      </gml:pointMember>
+                      <gml:pointMember>
+                        <gml:Point gml:id="P009">
+                          <gml:pos>9.00806 46.1249</gml:pos>
+                        </gml:Point>
+                      </gml:pointMember>
+                      <gml:pointMember>
+                        <gml:Point gml:id="P010">
+                          <gml:pos>6.29085 46.22985</gml:pos>
+                        </gml:Point>
+                      </gml:pointMember>
+                      <gml:pointMember>
+                        <gml:Point gml:id="P011">
+                          <gml:pos>6.65804 46.58377</gml:pos>
+                        </gml:Point>
+                      </gml:pointMember>
+                      <gml:pointMember>
+                        <gml:Point gml:id="P012">
+                          <gml:pos>7.43594 46.26856</gml:pos>
+                        </gml:Point>
+                      </gml:pointMember>
+                      <gml:pointMember>
+                        <gml:Point gml:id="P013">
+                          <gml:pos>10.23009 46.6625</gml:pos>
+                        </gml:Point>
+                      </gml:pointMember>
+                      <gml:pointMember>
+                        <gml:Point gml:id="P014">
+                          <gml:pos>8.53568 47.6837</gml:pos>
+                        </gml:Point>
+                      </gml:pointMember>
+                      <gml:pointMember>
+                        <gml:Point gml:id="P015">
+                          <gml:pos>8.83416 46.02261</gml:pos>
+                        </gml:Point>
+                      </gml:pointMember>
+                      <gml:pointMember>
+                        <gml:Point gml:id="P016">
+                          <gml:pos>8.22676 47.39954</gml:pos>
+                        </gml:Point>
+                      </gml:pointMember>
+                      <gml:pointMember>
+                        <gml:Point gml:id="P017">
+                          <gml:pos>9.06707 47.16505</gml:pos>
+                        </gml:Point>
+                      </gml:pointMember>
+                      <gml:pointMember>
+                        <gml:Point gml:id="P018">
+                          <gml:pos>7.85832 46.29688</gml:pos>
+                        </gml:Point>
+                      </gml:pointMember>
+                      <gml:pointMember>
+                        <gml:Point gml:id="P019">
+                          <gml:pos>7.88676 47.27406</gml:pos>
+                        </gml:Point>
+                      </gml:pointMember>
+                    </gml:MultiPoint>
+                  </gmd:polygon>
+                </gmd:EX_BoundingPolygon>
+              </gmd:geographicElement>
+            </gmd:EX_Extent>
+          </gmd:extent>
+        </gmd:MD_DataIdentification>
+      </gmd:identificationInfo>
+      <gmd:distributionInfo>
+        <gmd:MD_Distribution>
+          <gmd:distributionFormat>
+            <gmd:MD_Format>
+              <gmd:name>
+                <gco:CharacterString>URL</gco:CharacterString>
+              </gmd:name>
+              <gmd:version>
+                <gco:CharacterString/>
+              </gmd:version>
+            </gmd:MD_Format>
+          </gmd:distributionFormat>
+          <gmd:transferOptions>
+            <gmd:MD_DigitalTransferOptions>
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://www.envidat.ch/dataset/envidat-lwf-38</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>HTTPS</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:name>
+                    <gco:CharacterString>DATASET METADATA</gco:CharacterString>
+                  </gmd:name>
+                  <gmd:function>
+                    <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information">information</gmd:CI_OnLineFunctionCode>
+                  </gmd:function>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+              <gmd:onLine>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://www.wsl.ch/en/forest/forest-development-and-monitoring/long-term-forest-ecosystem-research-lwf.html</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>HTTPS</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:name>
+                    <gco:CharacterString>LWF MAIN PAGE</gco:CharacterString>
+                  </gmd:name>
+                  <gmd:function>
+                    <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="download">download</gmd:CI_OnLineFunctionCode>
+                  </gmd:function>
+                </gmd:CI_OnlineResource>
+              </gmd:onLine>
+            </gmd:MD_DigitalTransferOptions>
+          </gmd:transferOptions>
+        </gmd:MD_Distribution>
+      </gmd:distributionInfo>
+    </gmd:MD_Metadata>
+  </metadata>
+</record>


### PR DESCRIPTION
Changes:
* search doi and pid in `MD_Metadata.fileIdentifier` or `linkage`
* filter urls (doi, pid, source) of related_identifier in `doc.related_identifier` method ... reader/community does not need to filter in advance
* envidat: guess source ... first link of related_identifier with "https://www.envidat.ch/dataset/"
* fixed tests