### PR TITLE
Darus

### DIFF
--- a/mdingestion/ng/community/darus.py
+++ b/mdingestion/ng/community/darus.py
@@ -1,8 +1,21 @@
+from mdingestion.ng import classify
 from ..reader import DataCiteReader
 from ..sniffer import OAISniffer
 from ..format import format_value
+
+import logging
 
 
 class DarusDatacite(DataCiteReader):
     NAME = 'darus-oai_datacite'
     SNIFFER = OAISniffer
+
+    def discipline(self, doc):
+        classifier = classify.Classify()
+        result = classifier.map_discipline(doc.keywords)
+        if 'Various' not in result:
+            logging.debug(f"{result} keywords={doc.keywords}")
+        disc = result[0]
+        # if 'Various' in disc:
+        #    disc = 'Earth System Research'
+        return disc

--- a/mdingestion/ng/community/darus.py
+++ b/mdingestion/ng/community/darus.py
@@ -5,6 +5,3 @@ from ..sniffer import OAISniffer
 class DarusDatacite(DataCiteReader):
     NAME = 'darus-oai_datacite'
     SNIFFER = OAISniffer
-
-    def update(self, doc):
-        doc.discipline = self.discipline(doc)

--- a/mdingestion/ng/community/darus.py
+++ b/mdingestion/ng/community/darus.py
@@ -1,21 +1,10 @@
-from mdingestion.ng import classify
 from ..reader import DataCiteReader
 from ..sniffer import OAISniffer
-from ..format import format_value
-
-import logging
 
 
 class DarusDatacite(DataCiteReader):
     NAME = 'darus-oai_datacite'
     SNIFFER = OAISniffer
 
-    def discipline(self, doc):
-        classifier = classify.Classify()
-        result = classifier.map_discipline(doc.keywords)
-        if 'Various' not in result:
-            logging.debug(f"{result} keywords={doc.keywords}")
-        disc = result[0]
-        # if 'Various' in disc:
-        #    disc = 'Earth System Research'
-        return disc
+    def update(self, doc):
+        doc.discipline = self.discipline(doc)

--- a/mdingestion/ng/reader/datacite.py
+++ b/mdingestion/ng/reader/datacite.py
@@ -15,7 +15,7 @@ class DataCiteReader(XMLReader):
         doc.pid = self.find_pid('alternateIdentifier')
         doc.source = self.find_source('resource.identifier')
         doc.keywords = self.find('subject')
-        doc.discipline = format_value(self.find('subject'), type='string_words')
+        doc.discipline = self.discipline(doc)
         doc.related_identifier = self.find('relatedIdentifier')
         doc.creator = self.creator()
         doc.publisher = self.find('publisher')

--- a/tests/ng/community/test_darus.py
+++ b/tests/ng/community/test_darus.py
@@ -13,7 +13,7 @@ def test_datacite():
     assert 'https://doi.org/10.18419/darus-629' == doc.doi
     assert 'https://darus.uni-stuttgart.de/oai?verb=GetRecord&metadataPrefix=oai_datacite&identifier=doi:10.18419/darus-629' == doc.metadata_access  # noqa
     assert 'Medicine Health and Life Sciences' in doc.keywords
-    assert 'Medicine Health and Life Sciences' == doc.discipline
+    assert 'Medicine' == doc.discipline
     assert 'Jeltsch, Albert (Universität Stuttgart)' in doc.contact
     assert 'application/pdf' in doc.format
     assert len(doc.format) == 2


### PR DESCRIPTION
 datacite uses default classification = no need to set "discipline" in community mapfile for datacite communities EXCEPT if you want to set a fixcoded value instead of 'Various'.