### PR TITLE
Upload with "from" option

### DIFF
--- a/mdingestion/ng/cli.py
+++ b/mdingestion/ng/cli.py
@@ -105,12 +105,14 @@ def map(ctx, community, format, limit, force, no_linkcheck, summary):
 @click.option('--target', default='ckan', help='Target service: ckan (default)')
 @click.option('--limit', type=int, help='Limit')
 @click.option('--from', '-f', 'from_', type=int, help='From index')
+@click.option('--no-update', is_flag=True, help='do not update existing record')
 @click.option('--insecure', '-k', is_flag=True, help='Disable SSL verification')
 @click.pass_context
-def upload(ctx, community, iphost, auth, target, from_, limit, insecure):
+def upload(ctx, community, iphost, auth, target, from_, limit, no_update, insecure):
     try:
         upload = Upload(outdir=ctx.obj['outdir'], community=community)
-        upload.run(iphost=iphost, auth=auth, target=target, from_=from_, limit=limit, verify=not insecure)
+        upload.run(iphost=iphost, auth=auth, target=target, from_=from_, limit=limit,
+                   no_update=no_update, verify=not insecure)
     except Exception as e:
         logging.critical(f"upload: {e}", exc_info=True)
         raise click.ClickException(f"{e}")

--- a/mdingestion/ng/cli.py
+++ b/mdingestion/ng/cli.py
@@ -104,12 +104,13 @@ def map(ctx, community, format, limit, force, no_linkcheck, summary):
 @click.option('--auth', required=True, help='CKAN API key')
 @click.option('--target', default='ckan', help='Target service: ckan (default)')
 @click.option('--limit', type=int, help='Limit')
+@click.option('--from', '-f', 'from_', type=int, help='From index')
 @click.option('--insecure', '-k', is_flag=True, help='Disable SSL verification')
 @click.pass_context
-def upload(ctx, community, iphost, auth, target, limit, insecure):
+def upload(ctx, community, iphost, auth, target, from_, limit, insecure):
     try:
         upload = Upload(outdir=ctx.obj['outdir'], community=community)
-        upload.run(iphost=iphost, auth=auth, target=target, limit=limit, verify=not insecure)
+        upload.run(iphost=iphost, auth=auth, target=target, from_=from_, limit=limit, verify=not insecure)
     except Exception as e:
         logging.critical(f"upload: {e}", exc_info=True)
         raise click.ClickException(f"{e}")

--- a/mdingestion/ng/command/upload.py
+++ b/mdingestion/ng/command/upload.py
@@ -27,15 +27,19 @@ def upload(data, host=None, apikey=None, verify=True):
 
 
 class Upload(Command):
-    def run(self, iphost=None, auth=None, target=None, limit=None, verify=True):
-        self.upload_to_ckan(iphost=iphost, auth=auth, limit=limit, verify=verify)
+    def run(self, iphost=None, auth=None, target=None, from_=None, limit=None, verify=True):
+        self.upload_to_ckan(iphost=iphost, auth=auth, from_=from_, limit=limit, verify=verify)
 
-    def upload_to_ckan(self, iphost, auth, limit=None, verify=True):
+    def upload_to_ckan(self, iphost, auth, from_=None, limit=None, verify=True):
         self.walker = Walker(self.outdir)
         limit = limit or -1
         count = 0
         for filename in tqdm(self.walk(), ascii=True, desc=f"Uploading {self.community}",
                              unit=' records', total=limit):
+            if from_ and count < from_:
+                logging.info(f"skipping {filename}")
+                count += 1
+                continue
             if limit > 0 and count >= limit:
                 break
             logging.info(f"uploading {filename}")

--- a/mdingestion/ng/command/upload.py
+++ b/mdingestion/ng/command/upload.py
@@ -46,7 +46,10 @@ class Upload(Command):
             logging.info(f"uploading {filename}")
             with open(filename, 'rb') as fp:
                 data = json.load(fp)
-                upload(data=data, host=iphost, apikey=auth, verify=verify)
+                try:
+                    upload(data=data, host=iphost, apikey=auth, verify=verify)
+                except Exception:
+                    logging.error(f'upload failed: {filename}')
             count += 1
 
     def walk(self):

--- a/mdingestion/ng/command/upload.py
+++ b/mdingestion/ng/command/upload.py
@@ -17,6 +17,7 @@ def upload(data, host=None, apikey=None, verify=True):
         requests_kwargs = {'verify': False}
     try:
         with RemoteCKAN(f'http://{host}', apikey=apikey) as ckan:
+            # ckan.call_action('package_show', {'id': '62c44616-b8b3-4e35-8afa-81d4631a6456'})
             ckan.call_action('package_update', data, requests_kwargs=requests_kwargs)
             logging.info("upload update")
     except NotFound:

--- a/mdingestion/ng/command/upload.py
+++ b/mdingestion/ng/command/upload.py
@@ -11,15 +11,16 @@ from ..community import community
 import logging
 
 
-def upload(data, host=None, apikey=None, verify=True):
-    requests_kwargs = None
-    if not verify:
-        requests_kwargs = {'verify': False}
+def upload(data, host=None, apikey=None, no_update=False, verify=True):
+    requests_kwargs = {'verify': verify}
     try:
         with RemoteCKAN(f'http://{host}', apikey=apikey) as ckan:
-            # ckan.call_action('package_show', {'id': '62c44616-b8b3-4e35-8afa-81d4631a6456'})
-            ckan.call_action('package_update', data, requests_kwargs=requests_kwargs)
-            logging.info("upload update")
+            if no_update:
+                ckan.call_action('package_show', {'id': data['name']}, requests_kwargs=requests_kwargs)
+                logging.info("upload skip update")
+            else:
+                ckan.call_action('package_update', data, requests_kwargs=requests_kwargs)
+                logging.info("upload update")
     except NotFound:
         # TODO: clean up code ...
         with RemoteCKAN(f'http://{host}', apikey=apikey) as ckan:
@@ -28,10 +29,11 @@ def upload(data, host=None, apikey=None, verify=True):
 
 
 class Upload(Command):
-    def run(self, iphost=None, auth=None, target=None, from_=None, limit=None, verify=True):
-        self.upload_to_ckan(iphost=iphost, auth=auth, from_=from_, limit=limit, verify=verify)
+    def run(self, iphost=None, auth=None, target=None, from_=None, limit=None, no_update=False, verify=True):
+        self.upload_to_ckan(iphost=iphost, auth=auth, from_=from_, limit=limit,
+                            no_update=no_update, verify=verify)
 
-    def upload_to_ckan(self, iphost, auth, from_=None, limit=None, verify=True):
+    def upload_to_ckan(self, iphost, auth, from_=None, limit=None, no_update=False, verify=True):
         self.walker = Walker(self.outdir)
         limit = limit or -1
         count = 0
@@ -47,9 +49,9 @@ class Upload(Command):
             with open(filename, 'rb') as fp:
                 data = json.load(fp)
                 try:
-                    upload(data=data, host=iphost, apikey=auth, verify=verify)
-                except Exception:
-                    logging.error(f'upload failed: {filename}')
+                    upload(data=data, host=iphost, apikey=auth, no_update=no_update, verify=verify)
+                except Exception as e:
+                    logging.error(f'upload failed: {filename}. error: {e}')
             count += 1
 
     def walk(self):


### PR DESCRIPTION
Added options for upload command:
* `from` option: upload starting at index `from`.
* `--no-update`: skip update of record if record already exists.
* continue on upload error.