### PR TITLE
community group

### DIFF
--- a/mdingestion/ng/cli.py
+++ b/mdingestion/ng/cli.py
@@ -38,12 +38,12 @@ def cli(ctx, debug, dry_run, outdir):
 
 
 @cli.command()
-@click.option('--name', help='Community name or identifier')
+@click.option('--community', '-c', help='Community')
 @click.pass_context
-def list(ctx, name):
+def list(ctx, community):
     try:
         list = List()
-        list.run(name=name)
+        list.run(name=community)
     except Exception as e:
         logging.critical(f"list: {e}", exc_info=True)
         raise click.ClickException(f"{e}")

--- a/mdingestion/ng/cli.py
+++ b/mdingestion/ng/cli.py
@@ -38,11 +38,12 @@ def cli(ctx, debug, dry_run, outdir):
 
 
 @cli.command()
+@click.option('--name', help='Community name or identifier')
 @click.pass_context
-def list(ctx):
+def list(ctx, name):
     try:
         list = List()
-        list.run()
+        list.run(name=name)
     except Exception as e:
         logging.critical(f"list: {e}", exc_info=True)
         raise click.ClickException(f"{e}")

--- a/mdingestion/ng/command/harvest.py
+++ b/mdingestion/ng/command/harvest.py
@@ -3,7 +3,7 @@ from tqdm import tqdm
 from .base import Command
 from ..harvester import harvester
 from ..exceptions import UserInfo
-from ..community import community
+from ..community import community, communities
 
 import logging
 
@@ -11,7 +11,11 @@ import logging
 class Harvest(Command):
 
     def harvest(self, fromdate=None, limit=None, dry_run=False):
-        _community = community(self.community)
+        _communities = communities(self.community)
+        self._harvest(identifier=_communities[0], fromdate=fromdate, limit=limit, dry_run=dry_run)
+
+    def _harvest(self, identifier, fromdate=None, limit=None, dry_run=False):
+        _community = community(identifier)
         _harvester = harvester(
             community=_community.identifier,
             url=_community.url,

--- a/mdingestion/ng/command/harvest.py
+++ b/mdingestion/ng/command/harvest.py
@@ -18,7 +18,10 @@ class Harvest(Command):
                                # position=0,
                                unit=' community',
                                total=len(_communities)):
-            self._harvest(identifier, fromdate=fromdate, limit=limit, dry_run=dry_run)
+            try:
+                self._harvest(identifier, fromdate=fromdate, limit=limit, dry_run=dry_run)
+            except Exception as e:
+                logging.error(f"Harvesting off {identifier} failed.")
 
     def _harvest(self, identifier, fromdate=None, limit=None, dry_run=False):
         _community = community(identifier)

--- a/mdingestion/ng/command/harvest.py
+++ b/mdingestion/ng/command/harvest.py
@@ -15,6 +15,7 @@ class Harvest(Command):
         for identifier in tqdm(_communities,
                                ascii=True,
                                desc=f"Harvesting {self.community}",
+                               # position=0,
                                unit=' community',
                                total=len(_communities)):
             self._harvest(identifier, fromdate=fromdate, limit=limit, dry_run=dry_run)

--- a/mdingestion/ng/command/harvest.py
+++ b/mdingestion/ng/command/harvest.py
@@ -12,7 +12,12 @@ class Harvest(Command):
 
     def harvest(self, fromdate=None, limit=None, dry_run=False):
         _communities = communities(self.community)
-        self._harvest(identifier=_communities[0], fromdate=fromdate, limit=limit, dry_run=dry_run)
+        for identifier in tqdm(_communities,
+                               ascii=True,
+                               desc=f"Harvesting {self.community}",
+                               unit=' community',
+                               total=len(_communities)):
+            self._harvest(identifier, fromdate=fromdate, limit=limit, dry_run=dry_run)
 
     def _harvest(self, identifier, fromdate=None, limit=None, dry_run=False):
         _community = community(identifier)
@@ -31,7 +36,7 @@ class Harvest(Command):
             raise UserInfo(f'Found records={_harvester.total(limited=False)}')
         for record in tqdm(_harvester.harvest(),
                            ascii=True,
-                           desc=f"Harvesting {self.community}",
+                           desc=f"Harvesting {identifier}",
                            unit=' records',
                            total=_harvester.total()):
             _harvester.write_record(record, pretty_print=True)

--- a/mdingestion/ng/command/list.py
+++ b/mdingestion/ng/command/list.py
@@ -1,10 +1,12 @@
 
 from .base import Command
-from ..community import get_communities
+from ..community import community, communities
 
 
 class List(Command):
 
-    def run(self):
-        for community in get_communities():
-            print(f"{community.NAME}, {community.IDENTIFIER}, {community.URL}, {community.SCHEMA}, {community.SERVICE_TYPE}")  # noqa
+    def run(self, name=None):
+        name = name or 'all'
+        for identifier in communities(name):
+            com = community(identifier)
+            print(f"{com.NAME}, {com.IDENTIFIER}, {com.URL}, {com.SCHEMA}, {com.SERVICE_TYPE}")

--- a/mdingestion/ng/command/map.py
+++ b/mdingestion/ng/command/map.py
@@ -3,7 +3,7 @@ from tqdm import tqdm
 
 from .base import Command
 from ..walker import Walker
-from ..community import community
+from ..community import community, communities
 from ..writer import writer
 from ..validator import Validator
 
@@ -14,10 +14,21 @@ class Map(Command):
     def __init__(self, **args):
         super().__init__(**args)
         self.walker = Walker(self.outdir)
-        self._community = community(self.community)
+        # self._community = community(self.community)
         self.writer = None
 
     def run(self, format=format, force=False, linkcheck=True, limit=None, summary_dir=None):
+        _communities = communities(self.community)
+        for identifier in tqdm(_communities,
+                               ascii=True,
+                               desc=f"Map {self.community}",
+                               # position=0,
+                               unit=' community',
+                               total=len(_communities)):
+            self._community = community(identifier)
+            self._run(format=format, force=force, linkcheck=linkcheck, limit=limit, summary_dir=summary_dir)
+
+    def _run(self, format=format, force=False, linkcheck=True, limit=None, summary_dir=None):
         limit = limit or -1
         # TODO: refactor writer init
         self.writer = writer(format)
@@ -25,7 +36,8 @@ class Map(Command):
         validator = Validator(linkcheck=linkcheck)
         validator.summary['_invalid_files_'] = []
         count = 0
-        for filename in tqdm(self.walk(), ascii=True, desc=f"Map to {format}", unit=' records', total=limit):
+        for filename in tqdm(self.walk(), ascii=True, desc=f"Map {self._community.identifier} to {format}",
+                             unit=' records', total=limit):
             if limit > 0 and count >= limit:
                 break
             logging.info(f'mapping {filename}')

--- a/mdingestion/ng/command/map.py
+++ b/mdingestion/ng/command/map.py
@@ -18,6 +18,7 @@ class Map(Command):
         self.writer = None
 
     def run(self, format=format, force=False, linkcheck=True, limit=None, summary_dir=None):
+        # TODO: refactor community loop
         _communities = communities(self.community)
         for identifier in tqdm(_communities,
                                ascii=True,

--- a/mdingestion/ng/community/__init__.py
+++ b/mdingestion/ng/community/__init__.py
@@ -30,7 +30,9 @@ def _communities(cls=None):
 def get_communities():
     global COMMUNITIES
     if not COMMUNITIES:
-        COMMUNITIES = _communities()
+        COMMUNITIES = []
+        for com in _communities():
+            COMMUNITIES.append(com)
     return COMMUNITIES
 
 
@@ -40,3 +42,18 @@ def community(identifier):
         if community.IDENTIFIER == identifier:
             return community()
     raise CommunityNotSupported(f'Community not supported: {identifier}')
+
+
+def communities(name):
+    logging.debug(f'community name={name}')
+    com_list = []
+    for community in get_communities():
+        if name == 'all':
+            com_list.append(community.IDENTIFIER)
+        elif community.NAME == name:
+            com_list.append(community.IDENTIFIER)
+        elif community.IDENTIFIER == name:
+            com_list.append(community.IDENTIFIER)
+    if not com_list:
+        raise CommunityNotSupported(f'Community not supported: {name}')
+    return com_list

--- a/mdingestion/ng/community/__init__.py
+++ b/mdingestion/ng/community/__init__.py
@@ -8,6 +8,8 @@ import logging
 from importlib import import_module
 from pathlib import Path
 
+COMMUNITIES = None
+
 for f in Path(__file__).parent.glob("*.py"):
     module_name = f.stem
     if (not module_name.startswith("_")) and (module_name not in globals()):
@@ -16,13 +18,20 @@ for f in Path(__file__).parent.glob("*.py"):
 del import_module, Path
 
 
-def get_communities(cls=None):
+def _communities(cls=None):
     cls = cls or Community
     if len(cls.__subclasses__()) == 0:
         yield cls
     else:
         for subcls in cls.__subclasses__():
-            yield from get_communities(subcls)
+            yield from _communities(subcls)
+
+
+def get_communities():
+    global COMMUNITIES
+    if not COMMUNITIES:
+        COMMUNITIES = _communities()
+    return COMMUNITIES
 
 
 def community(identifier):

--- a/mdingestion/ng/harvester/base.py
+++ b/mdingestion/ng/harvester/base.py
@@ -29,9 +29,9 @@ class Harvester(object):
             else:
                 total = self.matches()
         except Exception as e:
-            msg = f"Harvester failed: {e}. url={self.url}"
+            msg = f"Harvester failed: {e}. community={self.community}, url={self.url}"
             logging.critical(msg, exc_info=True)
-            raise HarvesterError(f"Harvester failed: {e}")
+            raise HarvesterError(f"{msg}")
         return total
 
     def uid(self, record):
@@ -54,9 +54,9 @@ class Harvester(object):
                     break
                 yield record
         except Exception as e:
-            msg = f"Harvester failed: {e}. url={self.url}"
+            msg = f"Harvester failed: {e}. community={self.community}, url={self.url}"
             logging.critical(msg, exc_info=True)
-            raise HarvesterError(f"Harvester failed: {e}")
+            raise HarvesterError(f"{msg}")
 
     def get_records(self):
         raise NotImplementedError


### PR DESCRIPTION
Enable commands (harvest, map, upload) to loop over several communities. Communities can be selected by name and identifier.
