### PR TITLE
fix clean option

### DIFF
--- a/mdingestion/harvester/base.py
+++ b/mdingestion/harvester/base.py
@@ -52,7 +52,8 @@ class Harvester(object):
         if self.clean:
             outdir = os.path.join(self.outdir, self.community)
             logging.info(f'removing folder: {outdir}')
-            shutil.rmtree(outdir)
+            if os.path.exists(outdir):
+                shutil.rmtree(outdir)
         count = 0
         try:
             for record in self.get_records():


### PR DESCRIPTION
`clean` option failed when folder `oaidata/COMMUNITY` did not exist.